### PR TITLE
Add standalone reinforcement learning CMake project

### DIFF
--- a/rlpack/CMakeLists.txt
+++ b/rlpack/CMakeLists.txt
@@ -1,0 +1,93 @@
+cmake_minimum_required(VERSION 3.16)
+project(mlpack_rl LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Allow reuse of mlpack dependency discovery helpers.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../CMake")
+include(mlpack)
+
+option(RLPACK_DOWNLOAD_DEPENDENCIES "Automatically download third-party dependencies required by the reinforcement learning subset." ON)
+option(RLPACK_REQUIRE_DEPENDENCIES "Fail configuration if mandatory third-party dependencies are unavailable." ON)
+option(RLPACK_ENABLE_SMOKE_TEST "Build a small executable that validates the reinforcement learning headers." ON)
+
+if (RLPACK_DOWNLOAD_DEPENDENCIES)
+  set(MLPACK_DONT_FIND_MLPACK ON)
+  set(BLAS_FOUND ON CACHE BOOL "" FORCE)
+  fetch_mlpack(FALSE)
+  find_armadillo(${CMAKE_BINARY_DIR})
+  find_ensmallen(${CMAKE_BINARY_DIR})
+  find_cereal(${CMAKE_BINARY_DIR})
+else()
+  find_armadillo()
+  find_ensmallen()
+  find_cereal()
+endif()
+
+set(_rlpack_include_dirs ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+set(_rlpack_link_libraries)
+
+if (ARMADILLO_FOUND)
+  list(APPEND _rlpack_include_dirs ${ARMADILLO_INCLUDE_DIRS})
+  list(APPEND _rlpack_link_libraries ${ARMADILLO_LIBRARIES})
+endif()
+if (ENSMALLEN_FOUND)
+  list(APPEND _rlpack_include_dirs ${ENSMALLEN_INCLUDE_DIR})
+endif()
+if (CEREAL_FOUND)
+  list(APPEND _rlpack_include_dirs ${CEREAL_INCLUDE_DIR})
+endif()
+
+if (RLPACK_REQUIRE_DEPENDENCIES)
+  if (NOT ARMADILLO_FOUND)
+    message(FATAL_ERROR "Armadillo was not found; it is required to build the reinforcement learning subset.")
+  endif()
+  if (NOT ENSMALLEN_FOUND)
+    message(FATAL_ERROR "Ensmallen was not found; it is required to build the reinforcement learning subset.")
+  endif()
+  if (NOT CEREAL_FOUND)
+    message(FATAL_ERROR "cereal was not found; it is required to build the reinforcement learning subset.")
+  endif()
+endif()
+
+if (RLPACK_REQUIRE_DEPENDENCIES)
+  find_package(Boost 1.58 REQUIRED COMPONENTS filesystem program_options serialization system)
+else()
+  find_package(Boost 1.58 QUIET COMPONENTS filesystem program_options serialization system)
+endif()
+
+if (Boost_FOUND)
+  list(APPEND _rlpack_include_dirs ${Boost_INCLUDE_DIRS})
+  list(APPEND _rlpack_link_libraries ${Boost_LIBRARIES})
+elseif (RLPACK_REQUIRE_DEPENDENCIES)
+  message(FATAL_ERROR "Boost (>=1.58) was not found; it is required to build the reinforcement learning subset.")
+endif()
+
+if (RLPACK_ENABLE_SMOKE_TEST AND ARMADILLO_FOUND AND ENSMALLEN_FOUND AND CEREAL_FOUND AND Boost_FOUND)
+  add_executable(mlpack_rl_example src/rl_dummy.cpp)
+  target_include_directories(mlpack_rl_example PRIVATE ${_rlpack_include_dirs})
+  target_link_libraries(mlpack_rl_example PRIVATE ${_rlpack_link_libraries})
+endif()
+
+add_library(mlpack_rl INTERFACE)
+target_include_directories(mlpack_rl INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../src>
+  $<INSTALL_INTERFACE:include>
+  ${_rlpack_include_dirs}
+)
+target_link_libraries(mlpack_rl INTERFACE ${_rlpack_link_libraries})
+
+install(DIRECTORY ../src/mlpack/methods/reinforcement_learning
+        DESTINATION include/mlpack/methods)
+install(DIRECTORY ../src/mlpack/methods/ann
+        DESTINATION include/mlpack/methods)
+install(DIRECTORY ../src/mlpack/core
+        DESTINATION include/mlpack)
+install(FILES ../src/mlpack/methods/reinforcement_learning.hpp
+              ../src/mlpack/core.hpp
+              ../src/mlpack/base.hpp
+              ../src/mlpack/prereqs.hpp
+              ../src/mlpack/config.hpp
+        DESTINATION include/mlpack)

--- a/rlpack/README.md
+++ b/rlpack/README.md
@@ -1,0 +1,26 @@
+# mlpack reinforcement learning subset
+
+This directory provides a minimal CMake project that builds only the
+reinforcement learning components from the mlpack source tree.  It reuses the
+headers that live in `../src` and configures the third-party dependencies that
+these components rely on (Armadillo, ensmallen, cereal, and Boost).
+
+Two build targets are generated:
+
+* `mlpack_rl_example`: a trivial executable that includes
+  `mlpack/methods/reinforcement_learning/reinforcement_learning.hpp`.  This
+  serves as a quick smoke test to ensure that all dependencies are correctly
+  wired and that the headers compile.
+* `mlpack_rl`: an interface library that downstream projects can link against to
+  consume the reinforcement learning headers without the rest of mlpack.
+
+To build the subset, run the following commands from the repository root:
+
+```bash
+cmake -S rlpack -B rlpack/build
+cmake --build rlpack/build
+```
+
+The resulting interface target and install rules provide all of the headers
+required by the reinforcement learning code, including the ANN module and the
+core mlpack utilities that it depends on.

--- a/rlpack/src/rl_dummy.cpp
+++ b/rlpack/src/rl_dummy.cpp
@@ -1,0 +1,6 @@
+#include <mlpack/methods/reinforcement_learning/reinforcement_learning.hpp>
+
+int main()
+{
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a standalone `rlpack` CMake project that reuses mlpack's reinforcement learning headers and dependency discovery helpers
- provide an optional smoke-test executable plus install rules for the reinforcement learning, ANN, and core headers
- document how to configure and build the extracted reinforcement learning subset

## Testing
- cmake -S rlpack -B rlpack/build -DRLPACK_DOWNLOAD_DEPENDENCIES=OFF -DRLPACK_REQUIRE_DEPENDENCIES=OFF -DRLPACK_ENABLE_SMOKE_TEST=OFF
- cmake --build rlpack/build

------
https://chatgpt.com/codex/tasks/task_e_68d9b7cbec8c8327a0775ea03019bde4